### PR TITLE
Fixes for Windows

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -20,10 +20,6 @@ int numberOfSequences = 0;
 double precision = 0.00001;
 
 map<double, double> intervalsWithRoots;
-double abs(double a){
-	if(a < 0) a*=(-1);
-	return a;
-}
 
 void throwError(){
 	cout << "debilku" << endl;

--- a/main.cpp
+++ b/main.cpp
@@ -286,5 +286,9 @@ int main(){
 
 	newton();
 
+#ifdef _WIN32
+	system("pause");
+#endif
+
 	return 0;
 }


### PR DESCRIPTION
V tomhle pull requestu jsou dva fixy pro Windows
- redefinice funkce `abs`, která už byla v `stdlib.h` - funkce je teď ostraněna
- při spuštění programu mimo příkazovou řádku se program hned ukončil (okno se zavře, není vidět výstup) - při kompilaci na Windows se teď na konci programu přidá příkaz pause (takový to "Press any key to continue...")

[Zkompilované binárky pro Windows](https://mega.nz/#F!n9ZVBayQ!tZLaZARtIo090uVKGLHbMQ)
- jsou tam dvě - jedna zkompilovaná pomocí g++ a druhá pomocí Microsoft C++